### PR TITLE
Log the requested URL in the middleware

### DIFF
--- a/webui/middleware.go
+++ b/webui/middleware.go
@@ -11,6 +11,7 @@ import (
 func loggingMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		log.WithFields(log.Fields{
+			"url":           r.URL.String(),
 			"userAgent":     safe.Sanitize(r.UserAgent()),
 			"remoteAddr":    r.RemoteAddr,
 			"tls":           r.TLS != nil,


### PR DESCRIPTION
This time, more safety, since the method String of the struct url.URL takes care of escaping the raw URL of non-ASCII characters.
